### PR TITLE
feat: typeahead component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2127,6 +2127,11 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.8.tgz",
+      "integrity": "sha512-iAUjocygqXSGQb3zUHvAHwcf3BiMihlnphNSKCAqS6v9wNHlFe7260zNqoFjS/YBKJjbbvrXwY6/Wdg5mJ91Lw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2528,6 +2533,15 @@
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
+    "downshift": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-2.2.2.tgz",
+      "integrity": "sha512-vdt1AYiiD490PcPyscuX5Cqgv26jFiKD2fcjXdqoDgvbnKn4/Z48ccUmXIcGagzwEfYRrk3CxTuciIDG6+addA==",
+      "requires": {
+        "compute-scroll-into-view": "^1.0.2",
+        "prop-types": "^15.6.0"
+      }
     },
     "duplexer": {
       "version": "0.1.1",
@@ -6474,7 +6488,6 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "standard": "^12.0.1"
   },
   "dependencies": {
+    "downshift": "^2.2.2",
     "history": "^4.7.2",
     "lodash.isequal": "^4.5.0",
     "pouchdb": "^7.0.0",

--- a/src/js/components/new-bookmark.js
+++ b/src/js/components/new-bookmark.js
@@ -5,10 +5,23 @@ import { h, Component } from 'preact'
 
 import db from '../lib/db'
 import log from '../lib/log'
+import Typeahead from './typeahead'
 import uuidv4 from 'uuid/v4'
 import { getHumanDate } from '../lib/util'
 
 export default class NewBookmark extends Component {
+  constructor (props) {
+    super(props)
+    this.setState({
+      tags: []
+    })
+  }
+
+  async componentDidMount () {
+    const tags = await db.getTags()
+    this.setState({ tags })
+  }
+
   submit (bookmark = {}, save) {
     return (e) => {
       e.preventDefault()
@@ -31,7 +44,7 @@ export default class NewBookmark extends Component {
     }
   }
 
-  render ({ bookmark, onSave, onCancel }) {
+  render ({ bookmark, onSave, onCancel }, { tags }) {
     const save = async (bookmark) => {
       await db.put(bookmark)
       await onSave()
@@ -45,6 +58,7 @@ export default class NewBookmark extends Component {
               <div class='box'>
                 <div class='field'>
                   <div class='control'>
+                    <div class='label'>Title</div>
                     <input
                       class='input'
                       type='text'
@@ -55,6 +69,7 @@ export default class NewBookmark extends Component {
                 </div>
                 <div class='field'>
                   <div class='control'>
+                    <div class='label'>URL</div>
                     <input
                       class='input'
                       type='text'
@@ -65,9 +80,9 @@ export default class NewBookmark extends Component {
                 </div>
                 <div class='field'>
                   <div class='control'>
-                    <input
-                      class='input'
-                      type='text'
+                    <label class='label'>Description</label>
+                    <textarea
+                      class='textarea'
                       placeholder='Description'
                       value={bookmark ? bookmark.description : ''}
                     />
@@ -76,11 +91,11 @@ export default class NewBookmark extends Component {
                 </div>
                 <div class='field'>
                   <div class='control'>
-                    <input
-                      class='input'
-                      type='text'
+                    <Typeahead
+                      defaultInputValue={bookmark ? bookmark.tags.join(', ') : ''}
+                      label='Tags'
                       placeholder='Tags'
-                      value={bookmark ? bookmark.tags.join(', ') : ''}
+                      items={tags}
                     />
                   </div>
                   <p class='help'>Separate tags with commas. Tags are indexed for searching.</p>

--- a/src/js/components/search.js
+++ b/src/js/components/search.js
@@ -2,9 +2,23 @@
 
 import { h, Component } from 'preact'
 
+import db from '../lib/db'
 import log from '../lib/log'
+import Typeahead from './typeahead'
 
 export default class Search extends Component {
+  constructor (props) {
+    super(props)
+    this.setState({
+      tags: []
+    })
+  }
+
+  async componentDidMount () {
+    const tags = await db.getTags()
+    this.setState({ tags })
+  }
+
   submit (onQuery) {
     return async (e) => {
       e.preventDefault()
@@ -15,7 +29,7 @@ export default class Search extends Component {
     }
   }
 
-  render ({ onQuery }) {
+  render ({ onQuery }, { tags }) {
     const { bookmarks } = this.state
     return (
       <form onSubmit={this.submit(onQuery)}>
@@ -23,10 +37,10 @@ export default class Search extends Component {
           <div class='column'>
             <div class='field'>
               <div class='control'>
-                <input
-                  class='input'
-                  type='text'
+                <Typeahead
+                  label='Search'
                   placeholder='Search'
+                  items={tags}
                 />
               </div>
               <p class='help'>

--- a/src/js/components/typeahead.js
+++ b/src/js/components/typeahead.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-unused-vars */
+
+import Downshift from 'downshift/preact'
+import { h, Component } from 'preact'
+
+export default class Typeahead extends Component {
+  constructor (props) {
+    super(props)
+    this.setState({
+      inputValue: props.defaultInputValue || ''
+    })
+  }
+
+  render ({
+    label,
+    placeholder,
+    items
+  }, {
+    inputValue
+  }) {
+    const getItems = ({
+      isOpen,
+      inputValue,
+      getItemProps,
+      highlightedIndex
+    }) => {
+    }
+    return (
+      <Downshift defaultInputValue={inputValue}>
+        {({
+          getInputProps,
+          getItemProps,
+          getLabelProps,
+          getMenuProps,
+          highlightedIndex,
+          inputValue,
+          isOpen,
+          selectedItem
+        }) => {
+          const entries = inputValue.split(',').map(s => s.trim())
+          const currentEntries = entries.slice(0, -1)
+          const pendingEntry = entries.slice(-1)
+          const menuItems = pendingEntry.length
+            ? items
+              .filter((item, index) => {
+                return item.includes(pendingEntry) && !currentEntries.includes(item)
+              })
+              .map((item, index) => (
+                <li
+                  {...getItemProps({
+                    key: item,
+                    index,
+                    item: [...currentEntries, item].join(', ')
+                  })}
+                >
+                  <a class={highlightedIndex === index ? 'is-active' : ''}>{item}</a>
+                </li>
+              ))
+            : null
+          const menu = (isOpen && menuItems.length)
+            ? (
+              <aside class='menu'>
+                <ul {...getMenuProps({
+                  isOpen,
+                  class: 'menu-list box'
+                })}>
+                  {menuItems}
+                </ul>
+              </aside>
+            )
+            : null
+          return (
+            <div>
+              <label {...getLabelProps({ class: 'label' })}>{label}</label>
+              <input
+                {...getInputProps({
+                  class: 'input',
+                  type: 'text',
+                  placeholder
+                })}
+              />
+              {menu}
+            </div>
+          )
+        }}
+      </Downshift>
+    )
+  }
+}


### PR DESCRIPTION
Adds a generic `<Typeahead />` component. Currently used by the tags field, but will also be used to populate the lists field.